### PR TITLE
[FIX] Fix duplicated translations for unlabeled fields

### DIFF
--- a/navigator/views/abstract.py
+++ b/navigator/views/abstract.py
@@ -417,11 +417,10 @@ class AbstractModel(BaseView):
             model_cls = copy.deepcopy(self.model)
             fields = model_cls.columns(model_cls)
             for name, field in fields.items():
-                if 'label' in field.metadata:
-                    if 'original_label' in field.metadata:
-                        label = field.metadata.get('original_label')
-                    else:
-                        label = field.metadata.get('label', name)
+                if 'original_label' in field.metadata:
+                    label = field.metadata.get('original_label')
+                else:
+                    label = field.metadata.get('label', name)
                 translated_label = translator(label)
                 if label != translated_label:
                     new_metadata = dict(field.metadata)


### PR DESCRIPTION
If there was no label, there was no new assignment to the `label` variable, leaving the last found label

I removed the condition on the "label" key since it's not used in the next condition, and the `.get`dict method handles the non-existence of the key