### PR TITLE
Fixing Chunked Transfer Encoding Error

### DIFF
--- a/navigator/actions/zammad.py
+++ b/navigator/actions/zammad.py
@@ -441,7 +441,6 @@ class Zammad(AbstractTicket, RESTAction):
                     'Expires': expiring_date.strftime('%a, %d %b %Y %H:%M:%S GMT'),
                 }
             )
-            response.content_length = len(image_data)
             await response.prepare(request)
             await response.write(image_data)
             await response.write_eof()


### PR DESCRIPTION
Added file scaling system with Transfer-Encoding: chunked and resolved the conflict by removing the use of content_length in the response.